### PR TITLE
Style changes for clang-tidy warnings

### DIFF
--- a/2-Shortest-path/CMakeLists.txt
+++ b/2-Shortest-path/CMakeLists.txt
@@ -11,6 +11,3 @@ set (CMAKE_CXX_FLAGS "-std=c++11 -Wall ${CMAKE_CXX_FLAGS}")
 # create the main executable
 ## add additional .cpp files if needed
 add_executable(ece650-a2 a2-ece650.cpp parse_line.cpp graph.cpp)
-
-
-

--- a/2-Shortest-path/a2-ece650.cpp
+++ b/2-Shortest-path/a2-ece650.cpp
@@ -42,7 +42,7 @@ int main(
         std::list<unsigned> nums;
 
         //list to store shortest path
-        std::list<unsigned> short_path;
+        std::vector<unsigned> short_path;
 
         // if nothing was read, go to top of the while to check for eof
         if (line.empty()) {

--- a/2-Shortest-path/a2ece650.hpp
+++ b/2-Shortest-path/a2ece650.hpp
@@ -22,7 +22,7 @@ public:
     /// Creates the adjacency matrix
     bool adjacency_matrix(std::string &err_msg);
     /// Calculates the shortest path
-    bool dijkstra( std::list<unsigned> coordinates, std::list<unsigned> &short_path, std::string &err_msg);
+    bool dijkstra( std::list<unsigned> coordinates, std::vector<unsigned> &short_path, std::string &err_msg);
 };
 
 /**
@@ -36,5 +36,5 @@ bool parse_line (const std::string &line,
 
 bool parse_num (std::istringstream &input, std::list<unsigned> &nums);
 
-bool print_short_path (std::list<unsigned> short_path);
+bool print_short_path (std::vector<unsigned> short_path);
 

--- a/2-Shortest-path/graph.cpp
+++ b/2-Shortest-path/graph.cpp
@@ -81,7 +81,7 @@ bool Graph::adjacency_matrix(std::string &err_msg) {
     return false;
 }
 
-bool shortest_path (std::vector<int> prev, int source, int target, std::list<unsigned> &short_path, std::string &err_msg){
+bool shortest_path (std::vector<int> prev, int source, int target, std::vector<unsigned> &short_path, std::string &err_msg){
     int u = target;
 
     if (verbose2) {
@@ -90,7 +90,7 @@ bool shortest_path (std::vector<int> prev, int source, int target, std::list<uns
     
     if (prev[u] != -1 || u == source){
         while (u != -1){
-            short_path.push_front(u);
+            short_path.push_back(u);
             u = prev[u];
         }
         if (verbose2) {
@@ -107,7 +107,7 @@ bool shortest_path (std::vector<int> prev, int source, int target, std::list<uns
     
 }
 
-bool Graph::dijkstra( std::list<unsigned> coordinates, std::list<unsigned> &short_path, std::string &err_msg){
+bool Graph::dijkstra( std::list<unsigned> coordinates, std::vector<unsigned> &short_path, std::string &err_msg){
 
     if (coordinates.size() == 2) { 
 
@@ -123,6 +123,12 @@ bool Graph::dijkstra( std::list<unsigned> coordinates, std::list<unsigned> &shor
         if (source > V || target > V) {
             err_msg = "error: vertices out of bounds";
             return false;
+        }
+
+        if (source == target) {
+            short_path.push_back(target);
+            short_path.push_back(source);
+            return true;
         }
 
         std::list<unsigned> q;

--- a/2-Shortest-path/parse_line.cpp
+++ b/2-Shortest-path/parse_line.cpp
@@ -257,16 +257,15 @@ bool parse_line (const std::string &line,
 
 }
 
-bool print_short_path (std::list<unsigned> short_path) {
+bool print_short_path (std::vector<unsigned> short_path) {
 
-    for (unsigned i : short_path){
-        if (i != short_path.back()){
-            std::cout << i << "-";
+    for (auto i = short_path.rbegin(); i != short_path.rend(); ++i){
+        if (i != short_path.rend() - 1){
+            std::cout << *i << "-";
         } else {
-            std::cout << i;
+            std::cout << *i;
         }
     }
     std::cout << std::endl;
     return true;
-
 }


### PR DESCRIPTION
clang-tidy warnings
case when input is s a a  fixed (expected output: a-a)